### PR TITLE
Parameter types tweaks

### DIFF
--- a/qcodes/instrument/delegate/delegate_instrument.py
+++ b/qcodes/instrument/delegate/delegate_instrument.py
@@ -168,29 +168,28 @@ class DelegateInstrument(InstrumentBase):
         station: Station,
         parameters: Union[Mapping[str, Sequence[str]], Mapping[str, str]],
         setters: Mapping[str, MutableMapping[str, Any]],
-        units: Dict[str, str]
+        units: Mapping[str, str],
     ) -> None:
         """Add parameters to delegate instrument based on specified aliases,
         endpoints and setter methods"""
         for param_name, paths in parameters.items():
             if isinstance(paths, str):
-                self._create_and_add_parameter(
-                    group_name=param_name,
-                    station=station,
-                    paths=[paths],
-                    setter=setters.get(param_name),
-                    unit=units.get(param_name)
-                )
+                path_list: Sequence[str] = [paths]
+
             elif isinstance(paths, abc.Sequence):
-                self._create_and_add_parameter(
-                    group_name=param_name,
-                    station=station,
-                    paths=paths,
-                    setter=setters.get(param_name),
-                    unit=units.get(param_name)
-                )
+                path_list = paths
             else:
-                raise ValueError("Parameter paths should be either a string or list of strings.")
+                raise ValueError(
+                    "Parameter paths should be either a string or Sequence of strings."
+                )
+
+            self._create_and_add_parameter(
+                group_name=param_name,
+                station=station,
+                paths=path_list,
+                setter=setters.get(param_name),
+                unit=units.get(param_name),
+            )
 
     @staticmethod
     def _parameter_names(parameters: Sequence[Parameter]) -> List[str]:

--- a/qcodes/instrument/delegate/delegate_instrument.py
+++ b/qcodes/instrument/delegate/delegate_instrument.py
@@ -97,10 +97,10 @@ class DelegateInstrument(InstrumentBase):
         name: str,
         station: Station,
         parameters: Union[Mapping[str, Sequence[str]], Mapping[str, str]],
-        initial_values: Optional[Dict[str, Any]] = None,
+        initial_values: Optional[Mapping[str, Any]] = None,
         set_initial_values_on_load: bool = False,
-        setters: Optional[Dict[str, Dict[str, Any]]] = None,
-        units: Optional[Dict[str, str]] = None,
+        setters: Optional[Mapping[str, MutableMapping[str, Any]]] = None,
+        units: Optional[Mapping[str, str]] = None,
         metadata: Optional[Dict[Any, Any]] = None
     ):
         super().__init__(name=name, metadata=metadata)

--- a/qcodes/instrument/delegate/delegate_instrument.py
+++ b/qcodes/instrument/delegate/delegate_instrument.py
@@ -19,7 +19,7 @@ from qcodes.instrument.delegate.grouped_parameter import (
     DelegateGroupParameter,
     GroupedParameter,
 )
-from qcodes.instrument.parameter import DelegateParameter, Parameter
+from qcodes.instrument.parameter import Parameter
 from qcodes.station import Station
 
 _log = logging.getLogger(__name__)

--- a/qcodes/instrument/delegate/delegate_instrument.py
+++ b/qcodes/instrument/delegate/delegate_instrument.py
@@ -1,17 +1,26 @@
-from typing import Callable, List, Dict, Union, Any, Optional, Sequence
-
+import logging
+from collections import abc
 from functools import partial
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Union,
+)
 
+from qcodes.instrument.base import InstrumentBase
 from qcodes.instrument.delegate.grouped_parameter import (
     DelegateGroup,
     DelegateGroupParameter,
-    GroupedParameter
+    GroupedParameter,
 )
 from qcodes.instrument.parameter import DelegateParameter, Parameter
-from qcodes.instrument.base import InstrumentBase
 from qcodes.station import Station
-
-import logging
 
 _log = logging.getLogger(__name__)
 
@@ -87,7 +96,7 @@ class DelegateInstrument(InstrumentBase):
         self,
         name: str,
         station: Station,
-        parameters: Union[Dict[str, List[str]], Dict[str, str]],
+        parameters: Union[Mapping[str, Sequence[str]], Mapping[str, str]],
         initial_values: Optional[Dict[str, Any]] = None,
         set_initial_values_on_load: bool = False,
         setters: Optional[Dict[str, Dict[str, Any]]] = None,
@@ -157,8 +166,8 @@ class DelegateInstrument(InstrumentBase):
     def _create_and_add_parameters(
         self,
         station: Station,
-        parameters: Union[Dict[str, List[str]], Dict[str, str]],
-        setters: Dict[str, Dict[str, Any]],
+        parameters: Union[Mapping[str, Sequence[str]], Mapping[str, str]],
+        setters: Mapping[str, MutableMapping[str, Any]],
         units: Dict[str, str]
     ) -> None:
         """Add parameters to delegate instrument based on specified aliases,
@@ -172,7 +181,7 @@ class DelegateInstrument(InstrumentBase):
                     setter=setters.get(param_name),
                     unit=units.get(param_name)
                 )
-            elif isinstance(paths, list):
+            elif isinstance(paths, abc.Sequence):
                 self._create_and_add_parameter(
                     group_name=param_name,
                     station=station,
@@ -184,7 +193,7 @@ class DelegateInstrument(InstrumentBase):
                 raise ValueError("Parameter paths should be either a string or list of strings.")
 
     @staticmethod
-    def _parameter_names(parameters: List[Parameter]) -> List[str]:
+    def _parameter_names(parameters: Sequence[Parameter]) -> List[str]:
         """Get the endpoint names"""
         parameter_names = [_e.name for _e in parameters]
         if len(parameter_names) != len(set(parameter_names)):
@@ -214,8 +223,8 @@ class DelegateInstrument(InstrumentBase):
         self,
         group_name: str,
         station: Station,
-        paths: List[str],
-        setter: Optional[Dict[str, Any]] = None,
+        paths: Sequence[str],
+        setter: Optional[MutableMapping[str, Any]] = None,
         getter: Optional[Callable[..., Any]] = None,
         formatter: Optional[Callable[..., Any]] = None,
         unit: Optional[str] = None,

--- a/qcodes/instrument/delegate/delegate_instrument.py
+++ b/qcodes/instrument/delegate/delegate_instrument.py
@@ -121,7 +121,7 @@ class DelegateInstrument(InstrumentBase):
         station.my_instrument.my_param
 
         Args:
-            station: Measurement station
+            parent: Measurement station
             path: Relative path to parse
         """
         def _parse_path(parent: Any, elem: Sequence[str]) -> Any:


### PR DESCRIPTION
@guenp I made a few tweaks to your pr

* Use somewhat more generic types to prefer Sequence over List. This not only has the advantage that users can pass in tuple etc but also makes the type system verify that the input is not mutated.
* In a similar effort I changes a few instances of Dict to the generic type Mapping and MutableMapping.  We are still using in Dict across Qcodes, which I want to fix eventually so this is not possible everywhere. 

In general we prefer generic types Sequence, Iterable, Mapping etc as input arguments but concrete types as output arguments

* Fixed a variable name in a docstring and removed an unused import
* Condensed the if else logic a bit to reduce code duplication. 
